### PR TITLE
Add Github Updater to plugin header

### DIFF
--- a/amp-for-generatepress.php
+++ b/amp-for-generatepress.php
@@ -8,6 +8,7 @@ Author: Tom Usborne
 Author URI: https://generatepress.com
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
+GitHub Plugin URI: tomusborne/amp-for-generatepress
 */
 
 define( 'AMPGP_VERSION', 0.1 );


### PR DESCRIPTION
For as long as this is not a plugin in the w.org repo or not merged into GeneratePress itself, I would like to use https://github.com/afragen/github-updater for the updates.